### PR TITLE
Add Show instance for GeometryConstructionError

### DIFF
--- a/src/Data/Geometry/Geos/Geometry.hs
+++ b/src/Data/Geometry/Geos/Geometry.hs
@@ -111,6 +111,7 @@ data GeometryConstructionError
   = InvalidLinearRing
   | InvalidLineString
   | InvalidPolygon
+  deriving Show
 
 data Geometry a where
   PointGeometry :: Point -> SRID -> Geometry Point


### PR DESCRIPTION
Hi @ewestern,

thanks for your library. I noticed GeometryConstructionError doens't have a Show instance. I find it useful and I thought to add such instance with a PR.